### PR TITLE
[SAR-409]: Update for Dashboard Trends

### DIFF
--- a/src/calculators/TrendCalculator.js
+++ b/src/calculators/TrendCalculator.js
@@ -29,12 +29,24 @@ const calculateTrend = (resultData, predictionData, days) => {
   for (let i = 0; i < measureList.length; i += 1) {
     const measure = measureList[i];
     const result = resultMap.get(measure);
-    let changePercent = 0;
+    let percentChange = 0;
     if (result.base !== undefined) {
-      changePercent = Math.round(
+      percentChange = Math.round(
         ((result.latest.value - result.base.value) / result.base.value) * 100,
       );
     }
+
+    let subScoreTrends = [];
+    if (measure !== 'composite') {
+      for (let k = 0; k < result.latest.subScores.length; k += 1) {
+        const latestSubScore = result.latest.subScores[k];
+        const baseSubScore = result.base.subScores[k];
+        const subScoreChange = Math.round(
+          ((latestSubScore.value - baseSubScore.value) / result.base.value) * 100);
+        subScoreTrends.push({ measure: latestSubScore.measure, percentChange: subScoreChange });
+      }
+    }
+
     let futurePrediction = {};
     for (let j = 0; j < predictionData.length; j += 1) {
       if (predictionData[j].measure === measure && predictionData[j].Prophet_Predictions) {
@@ -43,7 +55,7 @@ const calculateTrend = (resultData, predictionData, days) => {
       }
     }
 
-    finalResult.push({ measure, changePercent, futurePrediction });
+    finalResult.push({ measure, percentChange, subScoreTrends, futurePrediction });
   }
 
   return finalResult;


### PR DESCRIPTION
# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-409](https://jira.amida-tech.com/browse/SAR-409)

# Other Repos' PR(s) Intended to Work With This PR

- [Dashboard PR #38](https://github.com/amida-tech/saraswati-dashboard/pull/38)

# How Things Worked (or Didn't) Before This PR

Didn't include subscore trends

# How Things Work Now (And How to Test)

Now subscore trends are calculated.  To test, make sure that you have data that is 7 days before the latest result. Using a `POST` request call `http://localhost:4000/api/v1/measures/trends`. Subscore trends should be in the returned value