### PR TITLE
[SAR-415]: Handle Invalid Trend Result

### DIFF
--- a/src/calculators/TrendCalculator.js
+++ b/src/calculators/TrendCalculator.js
@@ -48,7 +48,7 @@ const calculateTrend = (resultData, predictionData, days) => {
             ((latestSubScore.value - baseSubScore.value) / result.base.value) * 100);
           subScoreTrends.push({ measure: latestSubScore.measure, percentChange: subScoreChange });
         } else {
-          subScoreTrends.push({ measure: latestSubScore.measure, percentChange: 'NA' });
+          subScoreTrends.push({ measure: latestSubScore.measure });
         }
       }
     }
@@ -61,7 +61,12 @@ const calculateTrend = (resultData, predictionData, days) => {
       }
     }
 
-    finalResult.push({ measure, percentChange, subScoreTrends, futurePrediction });
+    if (percentChange !== 'NA') {
+      finalResult.push({ measure, percentChange, subScoreTrends, futurePrediction });
+    } else {
+      finalResult.push({ measure, subScoreTrends, futurePrediction });
+    }
+    
   }
 
   return finalResult;


### PR DESCRIPTION
If an error will be thrown the trend value is set to NA

# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-415](https://jira.amida-tech.com/browse/SAR-415)

# Other Repos' PR(s) Intended to Work With This PR

- [Dashboard #42](https://github.com/amida-tech/saraswati-dashboard/pull/42)

# How Things Worked (or Didn't) Before This PR

If there is an issue with trends calculation it would just crash and return a 500 error.

# How Things Work Now (And How to Test)

Will check before error is thrown. If an error would be thrown the trend value would be set to `NA`.