### PR TITLE
[SAR-479] - Prediction Routes

### DIFF
--- a/src/controllers/measure.controller.js
+++ b/src/controllers/measure.controller.js
@@ -36,37 +36,6 @@ const getTrends = async (req, res, next) => {
   }
 };
 
-// Access predictions made by time series
-const getPredictions = async (req, res, next) => {
-  try {
-    const predictions = await dao.findPredictions();
-    return res.send(predictions);
-  } catch (e) {
-    return next(e);
-  }
-};
-
-// Data time series to make predictions with
-const getPredictionData = async (req, res, next) => {
-  try {
-    const search = await dao.findMeasureResults(req.params);
-    const predictionData = search.sort((a, b) => a.date - b.date);
-    const compiledData = {
-      _id: req.params.measure,
-      DATE: {},
-      HEDIS0: {},
-    };
-    for (let i = 0; i < predictionData.length; i += 1) {
-      const result = predictionData[i];
-      compiledData.DATE[i.toString()] = new Date(result.date).getTime();
-      compiledData.HEDIS0[i.toString()] = result.value;
-    }
-    return res.send([compiledData]);
-  } catch (e) {
-    return next(e);
-  }
-};
-
 // Compiles individual info records into one JSON object
 const getInfo = async (req, res, next) => {
   try {
@@ -111,15 +80,6 @@ const postMeasureResults = async (req, res, next) => {
   }
 };
 
-const postPredictions = async (req, res, next) => {
-  try {
-    const predictions = await dao.insertPredictions(req.body);
-    return res.send(predictions);
-  } catch (e) {
-    return next(e);
-  }
-};
-
 const postInfo = async (req, res, next) => {
   try {
     const info = await dao.insertInfo(req.body);
@@ -133,12 +93,9 @@ module.exports = {
   getMeasures,
   getMeasureResults,
   getTrends,
-  getPredictions,
-  getPredictionData,
   getInfo,
   postBulkMeasures,
   postMeasure,
   postMeasureResults,
-  postPredictions,
   postInfo,
 };

--- a/src/controllers/prediction.controller.js
+++ b/src/controllers/prediction.controller.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-underscore-dangle */
+const dao = require('../config/dao');
+
+// Access predictions made by time series
+const getPredictions = async (req, res, next) => {
+  try {
+    const predictions = await dao.findPredictions();
+    return res.send(predictions);
+  } catch (e) {
+    return next(e);
+  }
+};
+
+// Data time series to make predictions with
+const getPredictionData = async (req, res, next) => {
+  try {
+    const search = await dao.findMeasureResults(req.params);
+    const predictionData = search.sort((a, b) => a.date - b.date);
+    const compiledData = {
+      _id: req.params.measure,
+      DATE: {},
+      HEDIS0: {},
+    };
+    for (let i = 0; i < predictionData.length; i += 1) {
+      const result = predictionData[i];
+      compiledData.DATE[i.toString()] = new Date(result.date).getTime();
+      compiledData.HEDIS0[i.toString()] = result.value;
+    }
+    return res.send([compiledData]);
+  } catch (e) {
+    return next(e);
+  }
+};
+
+const postPredictions = async (req, res, next) => {
+  try {
+    const predictions = await dao.insertPredictions(req.body);
+    return res.send(predictions);
+  } catch (e) {
+    return next(e);
+  }
+};
+
+module.exports = {
+  getPredictions,
+  getPredictionData,
+  postPredictions,
+};

--- a/src/routes/index.route.js
+++ b/src/routes/index.route.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const measureRoutes = require('./measure.route');
+const predictionRoutes = require('./prediction.route');
 
 const router = express.Router(); // eslint-disable-line new-cap
 
 router.get('/health-check', (req, res) => res.send('OK'));
 
 router.use('/measures', measureRoutes);
+router.use('/predictions', predictionRoutes);
 
 module.exports = router;

--- a/src/routes/measure.route.js
+++ b/src/routes/measure.route.js
@@ -16,13 +16,6 @@ router.route('/info')
   .get(measureCtrl.getInfo)
   .post(measureCtrl.postInfo);
 
-router.route('/predictions')
-  .get(measureCtrl.getPredictions)
-  .post(measureCtrl.postPredictions);
-
-router.route('/predictionData/:measure')
-  .get(measureCtrl.getPredictionData);
-
 router.route('/searchResults')
   .get(validate(paramValidation.searchMeasurements), measureCtrl.getMeasureResults);
 

--- a/src/routes/prediction.route.js
+++ b/src/routes/prediction.route.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const predictionCtrl = require('../controllers/prediction.controller');
+
+const router = express.Router(); // eslint-disable-line new-cap
+
+router.route('/')
+  .get(predictionCtrl.getPredictions)
+  .post(predictionCtrl.postPredictions);
+
+router.route('/data/:measure')
+  .get(predictionCtrl.getPredictionData);
+
+module.exports = router;

--- a/test/controllers/fail.measure.controller.test.js
+++ b/test/controllers/fail.measure.controller.test.js
@@ -7,12 +7,9 @@ const {
   getMeasures,
   getMeasureResults,
   getTrends,
-  getPredictions,
-  getPredictionData,
   postBulkMeasures,
   postMeasure,
   postMeasureResults,
-  postPredictions,
 } = require('../../src/controllers/measure.controller');
 
 const data = JSON.parse(fs.readFileSync(`${path.resolve()}/test/resources/bulk-data.json`));
@@ -73,22 +70,6 @@ describe('## measure.controller.js exceptions', () => {
     });
   });
 
-  describe('Test getPredictions', () => {
-    it('Should catch error and call next', async () => {
-      const next = jest.fn();
-      await getPredictions({ }, jest.fn(), next);
-      expect(next).toHaveBeenCalled();
-    });
-  });
-
-  describe('Test getPredictionData', () => {
-    it('Should catch error and call next', async () => {
-      const next = jest.fn();
-      await getPredictionData({ body: data }, jest.fn(), next);
-      expect(next).toHaveBeenCalled();
-    });
-  });
-
   describe('Test postBulkMeasures upload', () => {
     it('Should catch error and call next', async () => {
       const next = jest.fn();
@@ -109,14 +90,6 @@ describe('## measure.controller.js exceptions', () => {
     it('Should catch error and call next', async () => {
       const next = jest.fn();
       await postMeasureResults({ body: data }, jest.fn(), next);
-      expect(next).toHaveBeenCalled();
-    });
-  });
-
-  describe('Test postPredictions', () => {
-    it('Should catch error and call next', async () => {
-      const next = jest.fn();
-      await postPredictions({ body: data }, jest.fn(), next);
       expect(next).toHaveBeenCalled();
     });
   });

--- a/test/controllers/fail.prediction.controller.test.js
+++ b/test/controllers/fail.prediction.controller.test.js
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+  getPredictions,
+  getPredictionData,
+  postPredictions,
+} = require('../../src/controllers/prediction.controller');
+
+const data = JSON.parse(fs.readFileSync(`${path.resolve()}/test/resources/bulk-data.json`));
+const queryParams = { measure: 'drre' };
+
+jest.mock('../../src/config/dao', () => {
+  const originalModule = jest.requireActual('../../src/config/dao');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    findMeasureResults: jest.fn().mockImplementation(() => {
+      throw new Error();
+    }),
+    findPredictions: jest.fn().mockImplementation(() => {
+      throw new Error();
+    }),
+    insertPredictions: jest.fn().mockImplementation(() => {
+      throw new Error();
+    }),
+  };
+});
+
+describe('## prediction.controller.js exceptions', () => {
+  describe('Test getPredictions', () => {
+    it('Should catch error and call next', async () => {
+      const next = jest.fn();
+      await getPredictions({ }, jest.fn(), next);
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test getPredictionData', () => {
+    it('Should catch error and call next', async () => {
+      const next = jest.fn();
+      await getPredictionData({ body: data }, jest.fn(), next);
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test postPredictions', () => {
+    it('Should catch error and call next', async () => {
+      const next = jest.fn();
+      await postPredictions({ body: data }, jest.fn(), next);
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/controllers/measure.controller.test.js
+++ b/test/controllers/measure.controller.test.js
@@ -7,13 +7,10 @@ const {
   getMeasures,
   getMeasureResults,
   getTrends,
-  getPredictions,
-  getPredictionData,
   getInfo,
   postBulkMeasures,
   postMeasure,
   postMeasureResults,
-  postPredictions,
   postInfo,
 } = require('../../src/controllers/measure.controller');
 
@@ -32,7 +29,6 @@ jest.mock('../../src/config/dao', () => {
     insertMeasure: jest.fn(() => {}),
     insertMeasures: jest.fn(() => []),
     insertMeasureResults: jest.fn(() => []),
-    insertPredictions: jest.fn(() => []),
     insertInfo: jest.fn(() => {}),
   };
 });
@@ -78,22 +74,6 @@ describe('## measure.controller.js', () => {
     });
   });
 
-  describe('Test getPredictions', () => {
-    it('Should call response.send', async () => {
-      const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
-      await getPredictions({ }, response, jest.fn());
-      expect(response.send).toHaveBeenCalled();
-    });
-  });
-
-  describe('Test getPredictionData', () => {
-    it('Should call response.send', async () => {
-      const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
-      await getPredictionData({ params: queryOrParams }, response, jest.fn());
-      expect(response.send).toHaveBeenCalled();
-    });
-  });
-
   describe('Test getInfo', () => {
     it('Should call response.send', async () => {
       const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
@@ -122,14 +102,6 @@ describe('## measure.controller.js', () => {
     it('Should call response.send', async () => {
       const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
       await postMeasureResults({ body: data }, response, jest.fn());
-      expect(response.send).toHaveBeenCalled();
-    });
-  });
-
-  describe('Test postPredictions', () => {
-    it('Should call response.send', async () => {
-      const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
-      await postPredictions({ body: data }, response, jest.fn());
       expect(response.send).toHaveBeenCalled();
     });
   });

--- a/test/controllers/predictions.controller.test.js
+++ b/test/controllers/predictions.controller.test.js
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+  getPredictions,
+  getPredictionData,
+  postPredictions,
+} = require('../../src/controllers/prediction.controller');
+
+const data = JSON.parse(fs.readFileSync(`${path.resolve()}/test/resources/bulk-data.json`));
+const queryOrParams = { measure: 'drre' };
+
+jest.mock('../../src/config/dao', () => {
+  const originalModule = jest.requireActual('../../src/config/dao');
+  return {
+    __esModule: true,
+    ...originalModule,
+    findMeasureResults: jest.fn(() => []),
+    findPredictions: jest.fn(() => {}),
+    insertPredictions: jest.fn(() => []),
+  };
+});
+
+describe('## prediction.controller.js', () => {
+  describe('Test getPredictions', () => {
+    it('Should call response.send', async () => {
+      const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
+      await getPredictions({ }, response, jest.fn());
+      expect(response.send).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test getPredictionData', () => {
+    it('Should call response.send', async () => {
+      const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
+      await getPredictionData({ params: queryOrParams }, response, jest.fn());
+      expect(response.send).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test postPredictions', () => {
+    it('Should call response.send', async () => {
+      const response = { send: jest.fn().mockReturnValue(Promise.resolve()) };
+      await postPredictions({ body: data }, response, jest.fn());
+      expect(response.send).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Also updated the tests

# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-479](https://jira.amida-tech.com/browse/SAR-479)

# Other Repos' PR(s) Intended to Work With This PR

- [Time Series #6](https://github.com/amida-tech/saraswati-time-series/pull/6)

# How Things Worked (or Didn't) Before This PR

All prediction endpoints were in the `measure` route

# How Things Work Now (And How to Test)

The prediction endpoints now have their own `prediction` route.

`measures/predictions` -> `predictions`
`measures/predictionData` -> `predictions/data`