### PR TITLE
Update trend calculation to change in percent rather than percent change

### DIFF
--- a/src/calculators/TrendCalculator.js
+++ b/src/calculators/TrendCalculator.js
@@ -31,9 +31,7 @@ const calculateTrend = (resultData, predictionData, days) => {
     const result = resultMap.get(measure);
     let percentChange = 0;
     if (result.base !== undefined) {
-      percentChange = Math.round(
-        ((result.latest.value - result.base.value) / result.base.value) * 100,
-      );
+      percentChange = Math.round(result.latest.value - result.base.value);
     } else {
       percentChange = 'NA';
     }
@@ -44,9 +42,7 @@ const calculateTrend = (resultData, predictionData, days) => {
         const latestSubScore = result.latest.subScores[k];
         if (result.base !== undefined) {
           const baseSubScore = result.base.subScores[k];
-          const subScoreChange = Math.round(
-            ((latestSubScore.value - baseSubScore.value) / result.base.value) * 100,
-          );
+          const subScoreChange = Math.round(latestSubScore.value - baseSubScore.value);
           subScoreTrends.push({ measure: latestSubScore.measure, percentChange: subScoreChange });
         } else {
           subScoreTrends.push({ measure: latestSubScore.measure });

--- a/test/calculators/TrendCalculator.test.js
+++ b/test/calculators/TrendCalculator.test.js
@@ -28,8 +28,8 @@ describe(' Trend Calculation test ', () => {
   });
 
   test('Check calculations', () => {
-    expect(resultArray[0].percentChange).toEqual(-30);
-    expect(resultArray[2].percentChange).toEqual(-18);
-    expect(resultArray[4].percentChange).toEqual(23);
+    expect(resultArray[0].percentChange).toEqual(-21);
+    expect(resultArray[2].percentChange).toEqual(-8);
+    expect(resultArray[4].percentChange).toEqual(11);
   });
 });


### PR DESCRIPTION
# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-483](https://jira.amida-tech.com/browse/SAR-483)

# How Things Worked (or Didn't) Before This PR

The trend was being calculated as the percent change.

Example:
10% -> 20% == 100% change

# How Things Work Now (And How to Test)

Now the trend is being calculated as the change in percent.

10% -> 20% == 10% change