### PR TITLE
[SAR-569]: Demo Dockerfile

### DIFF
--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -1,0 +1,15 @@
+FROM node:16.14.2-alpine3.15
+
+WORKDIR /app
+
+COPY ./package.json .
+COPY ./yarn.lock .
+COPY .env.example /app/.env 
+COPY ./src ./src
+COPY ./initialize ./initialize
+COPY ./test-data-generator.js .
+COPY ./test-data-settings.js .
+
+RUN yarn
+EXPOSE 4000
+CMD [ "yarn", "start" ]

--- a/initialize/hedis-info.json
+++ b/initialize/hedis-info.json
@@ -239,8 +239,8 @@
         "_id" : "cise-1",
         "cise-1" : {
             "domainOfCare" : "ECDS",
-            "title" : "Childhood Immunization Status: Influenza",
-            "displayLabel" : "CIS-E: Influenza",
+            "title" : "Childhood Immunization Status: DTaP",
+            "displayLabel" : "CIS-E: DTaP",
             "measureType" : "process",
             "weight" : 3,
             "hasSubMeasures" : false,

--- a/src/consumer/consumer.js
+++ b/src/consumer/consumer.js
@@ -18,6 +18,14 @@ async function kafkaRunner() {
 
   await consumer.connect();
 
+  const admin = kafka.admin();
+  await admin.connect();
+  await admin.createTopics({
+    topics: [{
+      topic: config.kafkaConfig.queue,
+    }],
+  });
+  await admin.disconnect();
   await consumer.subscribe({ topic: config.kafkaConfig.queue, fromBeginning: false });
   await consumer.run({
     eachMessage: async ({ topic, partition, message }) => {


### PR DESCRIPTION
Also includes automatically created topics in-case it doesn't exist and slight fix to hedis-info for CIS-E

# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-569](https://https://amida.atlassian.net/browse/SAR-569)

# How Things Worked (or Didn't) Before This PR

1. Only one docker file, and it didn't include the data generation script
2. Hedis-info had two influenza measures for CIS-E
3. If the Kafka topic for HeRA didn't exist it would throw errors

# How Things Work Now (And How to Test)

1. Created `Dockerfile.demo` which includes the data generation script
2. CIS-E sub measure 1 is now properly label as DTaP
3. On start up automatically creates the correct Kafka topic, but the command does nothing if it already exists